### PR TITLE
Fixed angle of rotation

### DIFF
--- a/swift/Tensorflow/TensorflowGraph.mm
+++ b/swift/Tensorflow/TensorflowGraph.mm
@@ -122,13 +122,13 @@ const int kAverageEveryXFrames   = 50;   // Output average processing time every
             break;
         case UIDeviceOrientationLandscapeLeft:
         {
-            angle = 0.0;
+            angle = -M_PI;
             transform = CGAffineTransformScale(transform, float(kGraphImageWidth)/pixelBufWidth, float(kGraphImageHeight)/pixelBufHeight);
         }
             break;
         case UIDeviceOrientationLandscapeRight:
         {
-            angle = M_PI;
+            angle = 0.0;
             transform = CGAffineTransformScale(transform, float(kGraphImageWidth)/pixelBufWidth, float(kGraphImageHeight)/pixelBufHeight);
         }
             break;


### PR DESCRIPTION
The app did not work in landscape mode because the angles used for CGAffineTransformRotate was wrong. Given that angle = -90 degrees for portrait mode and 90 degrees for portrait upside-down, landscape-left should require -180 degree (-pi) rotation and landscape-right should require zero degree rotation.